### PR TITLE
Added features focusNextAt and focusPrevOnEmpty

### DIFF
--- a/jquery.tabbable.js
+++ b/jquery.tabbable.js
@@ -133,4 +133,41 @@
 			}).length;
 		}
 	}
+	/**
+	 * Makes field automaticaly jumps to next when value gets to certain amount of characters
+	 * @param 
+	 * (int) number - Number of characters when to jump to next field
+	 * @return this
+	 **/
+	$.fn.focusNextAt = function(number){
+		$(this).each(function(){
+			var obj = $(this);
+			obj.bind("keydown",function(evt){
+				if (evt.which != 9 && evt.which != 8 && evt.which != 18 && evt.which != 13 && evt.which != 27 && evt.which !=16) {
+					console.log(evt.which);
+					if (obj.val().length >= number) {
+						$.focusNext();
+					};
+				}
+			})
+		});
+		return this;
+	}
+	/**
+	 * Makes field automaticaly jumps to previous when pressed backspace and field is empty. For example if I
+	 * Erase the whole field, leaving it blank and then pressing backspace one more time it returns to previous field.g	 
+	 * @returns this
+	 **/
+	$.fn.focusPrevOnEmpty = function(){
+		$(this).each(function(){
+			var obj = $(this);
+			obj.bind("keydown",function(evt){
+				if (obj.val().length == 0 && evt.which == 8) {
+					$.focusPrev();
+				}
+			})
+		})
+		
+		return this;
+	}
 })(jQuery);


### PR DESCRIPTION
Sometimes it's really good to UX if fields jumps to the next one when done completed. This occurs when we know the exactly amount of characters that field should be. For example, we could have 3 date fields for Year, Month and Day, respectively. So we make year jumps to month as soon as I type de 4 digit on year and month jump to day as soon as I type the second digit on month. And given that, it's really nice that we can erase continuously from one field to the previous to, so if I typed the wrong date, I can erase the days, and cursor will jump to the end of month, if I erase the whole month too, it will jump to the end of the year field. Said that, those two simple functions have helped me make some forms really better in a ux point of view, and I would be glad if it helps more people two.
