### PR TITLE
Adding options for disabling and enabling tabbable elements

### DIFF
--- a/jquery.tabbable.js
+++ b/jquery.tabbable.js
@@ -66,40 +66,27 @@
 		opts.key = opts.key || true;
 
 		tabIndexes[opts.key] = tabIndexes[opts.key] || [];
-		if(tabIndexes[opts.key].length === 0) {
+		tabbables[opts.key] = tabbables[opts.key] || [];
 
-			tabbables[opts.key] = $(":tabbable",opts.container).toArray();
-			if(opts.exclude && opts.exclude.length) {
-				if(opts.exclude instanceof jQuery) {
-					opts.exclude = opts.exclude.toArray();
-				}
-				tabbables[opts.key] = $(tabbables[opts.key]).not($(":tabbable", opts.exclude)).toArray();
+		var newTabbables = $(":tabbable",opts.container).toArray();
+		if(opts.exclude && opts.exclude.length) {
+			if(opts.exclude instanceof jQuery) {
+				opts.exclude = opts.exclude.toArray();
 			}
+			newTabbables = $(newTabbables).not($(":tabbable", opts.exclude)).toArray();
+		}
 
-			
-			tabbables[opts.key].forEach(function(el) {
+		if(newTabbables.length > 0) {
+			tabbables[opts.key] = tabbables[opts.key].concat(newTabbables);
+
+		
+			newTabbables.forEach(function(el) {
 				tabIndexes[opts.key].push(el.tabIndex);
 				el.tabIndex = -1;
 			});
-		} else {
-			var newTabbables = $(":tabbable",opts.container).toArray();
-			if(opts.exclude && opts.exclude.length) {
-				if(opts.exclude instanceof jQuery) {
-					opts.exclude = opts.exclude.toArray();
-				}
-				newTabbables = $(newTabbables).not($(":tabbable", opts.exclude)).toArray();
-			}
-
-			if(newTabbables.length > 0) {
-				tabbables[opts.key].concat(newTabbables);
-
-			
-				newTabbables.forEach(function(el) {
-					tabIndexes[opts.key].push(el.tabIndex);
-					el.tabIndex = -1;
-				});
-			}
 		}
+
+
 		return opts.key;
 	}
 

--- a/jquery.tabbable.js
+++ b/jquery.tabbable.js
@@ -195,7 +195,7 @@
 			return ( isTabIndexNaN || tabIndex >= 0 ) && focusable(element, !isTabIndexNaN);
 		}
 	});
-
+	
 	/**
 	 * focussable function, taken from jQuery UI Core
 	 * @param element
@@ -214,7 +214,7 @@
 			img = $('img[usemap=#' + mapName + ']')[0];
 			return !!img && visible(img);
 		}
-		return ( /input|select|textarea|button|object/.test(nodeName) ?
+		return ( /^(input|select|textarea|button|object)$/.test(nodeName) ?
 			!element.disabled :
 			'a' === nodeName ?
 				element.href || isTabIndexNotNaN :

--- a/jquery.tabbable.js
+++ b/jquery.tabbable.js
@@ -52,10 +52,12 @@
 
 	/** 
 	 * Disables tabbing to all tabbable elements. 
-	 * {
+	 * options: 
 	 *	container: Limit inside container, defaults to document.
-	 *  exclude: Excludes elements inside container. Accepts an array of elements
-	 * }
+	 *  exclude: Excludes elements inside container. Accepts an array of elements or jQuery selection.
+	 *  key: Any acceptable array element key, used to create disabled tabbing groups. Defaults to true
+	 *
+	 * Returns: key
 	 */
 	$.disableTabbing = function(options) {
 		var opts = options || {};
@@ -66,11 +68,12 @@
 		tabIndexes[opts.key] = tabIndexes[opts.key] || [];
 
 		tabbables[opts.key] = $(":tabbable",opts.container);
+		debugger;
 		if(opts.exclude && opts.exclude.length) {
 			if(opts.exclude instanceof jQuery) {
 				opts.exclude = opts.exclude.toArray();
 			}
-			tabbables[opts.key] = $(tabbables[opts.key]).not(":tabbable", opts.exclude);
+			tabbables[opts.key] = $(tabbables[opts.key]).not($(":tabbable", opts.exclude));
 		}
 
 		
@@ -81,10 +84,18 @@
 		return opts.key;
 	}
 
+
+
+	/** 
+	 * Enables tabbing to all tabbable elements. 
+	 *  optKey: Key returned from disableTabbing. Defaults to true
+	 *
+	 * Returns: Boolean if tabIndexes were changed.
+	 */
 	$.enableTabbing = function(optKey) {
 		var key = optKey || true;
 		if(tabIndexes[key] && tabIndexes[key].length > 0) {
-			tabbables.each(function() { this.tabIndex = tabIndexes[key].shift(); });
+			tabbables[key].each(function() { this.tabIndex = tabIndexes[key].shift(); });
 			delete tabbables[key];
 			delete tabIndexes[key];
 			return true;

--- a/jquery.tabbable.js
+++ b/jquery.tabbable.js
@@ -68,7 +68,6 @@
 		tabIndexes[opts.key] = tabIndexes[opts.key] || [];
 
 		tabbables[opts.key] = $(":tabbable",opts.container);
-		debugger;
 		if(opts.exclude && opts.exclude.length) {
 			if(opts.exclude instanceof jQuery) {
 				opts.exclude = opts.exclude.toArray();
@@ -141,7 +140,7 @@
 
 		// Support: Opera <= 12.12
 		// Opera reports offsetWidths and offsetHeights less than zero on some elements
-		return (!jQuery.support.reliableHiddenOffsets && ((elem.style && elem.style.display) || jQuery.css( elem, "display" )) === "none");
+		return (elem.offsetWidth <= 0 && elem.offsetHeight <= 0 && window.getComputedStyle(elem).display !== 'inline') || (!jQuery.support.reliableHiddenOffsets && ((elem.style && elem.style.display) || jQuery.css( elem, "display" )) === "none");
 	};
 
 	jQuery.expr.filters.visible = function( elem ) {

--- a/jquery.tabbable.js
+++ b/jquery.tabbable.js
@@ -11,6 +11,9 @@
 (function($){
 	'use strict';
 
+	var tabIndexes = [];
+	var tabbables = [];
+
 	/**
 	 * Focusses the next :focusable element. Elements with tabindex=-1 are focusable, but not tabable.
 	 * Does not take into account that the taborder might be different as the :tabbable elements order
@@ -47,6 +50,50 @@
 		selectPrevTabbableOrFocusable(':tabbable');
 	};
 
+	/** 
+	 * Disables tabbing to all tabbable elements. 
+	 * {
+	 *	container: Limit inside container, defaults to document.
+	 *  exclude: Excludes elements inside container. Accepts an array of elements
+	 * }
+	 */
+	$.disableTabbing = function(options) {
+		var opts = options || {};
+		opts.container = opts.container || document;
+		opts.exclude = opts.exclude || [];
+		opts.key = opts.key || true;
+
+		tabIndexes[opts.key] = tabIndexes[opts.key] || [];
+
+		tabbables[opts.key] = $(":tabbable",opts.container);
+		if(opts.exclude && opts.exclude.length) {
+			if(opts.exclude instanceof jQuery) {
+				opts.exclude = opts.exclude.toArray();
+			}
+			tabbables[opts.key] = $(tabbables[opts.key]).not(":tabbable", opts.exclude);
+		}
+
+		
+		tabbables[opts.key].each(function() {
+			tabIndexes[opts.key].push(this.tabIndex);
+			this.tabIndex = -1;
+		});
+		return opts.key;
+	}
+
+	$.enableTabbing = function(optKey) {
+		var key = optKey || true;
+		if(tabIndexes[key] && tabIndexes[key].length > 0) {
+			tabbables.each(function() { this.tabIndex = tabIndexes[key].shift(); });
+			delete tabbables[key];
+			delete tabIndexes[key];
+			return true;
+		}
+
+		return false;
+	}
+
+
 	function selectNextTabbableOrFocusable(selector){
 		var selectables = $(selector);
 		var current = $(':focus');
@@ -74,6 +121,22 @@
 
 		selectables.eq(prevIndex).focus();
 	}
+
+	/**
+	 * Correct jquery filters for Chrome 
+	 */
+
+	jQuery.expr.filters.hidden = function( elem ) {
+
+		// Support: Opera <= 12.12
+		// Opera reports offsetWidths and offsetHeights less than zero on some elements
+		return (!jQuery.support.reliableHiddenOffsets && ((elem.style && elem.style.display) || jQuery.css( elem, "display" )) === "none");
+	};
+
+	jQuery.expr.filters.visible = function( elem ) {
+		return !jQuery.expr.filters.hidden( elem );
+	};
+
 
 	/**
 	 * :focusable and :tabbable, both taken from jQuery UI Core
@@ -133,4 +196,6 @@
 			}).length;
 		}
 	}
+
+
 })(jQuery);


### PR DESCRIPTION
These new functions are useful for disabling tabbing functionality behind modals, or in any other logical group.

One would either use this before creating a modal:

```
$.disableTabbing();
```

or if the element exists on the page:

```
$.disableTabbing({exclude: $(".modal")});
```

Either way, using this will return the page to normal:

```
$.enableTabbing();
```

It's important to note my changes update a core filter in jQuery, :hidden. It incorrectly includes inline elements with 0 offsetHeight & offsetWidth. I'm happy to resubmit without it, but in testing it seems core that it needs to be done. I've submitted a bug to jQuery on the matter.

Future updates:
 I'll likely teach tabIndexes[] to keep track of when the index doesn't actually exist as an attribute so it doesn't get added to elements which didn't have it previously.
