### PR TITLE
fix focusable, stricter checking for nodeName

### DIFF
--- a/jquery.tabbable.js
+++ b/jquery.tabbable.js
@@ -119,7 +119,7 @@
 			img = $('img[usemap=#' + mapName + ']')[0];
 			return !!img && visible(img);
 		}
-		return ( /input|select|textarea|button|object/.test(nodeName) ?
+		return ( /^(input|select|textarea|button|object)$/.test(nodeName) ?
 			!element.disabled :
 			'a' === nodeName ?
 				element.href || isTabIndexNotNaN :


### PR DESCRIPTION
For correct work with custom elements (e.g. `single-select-tree`, `multi-select-list`, `submit-button`, `search-input`, etc.).
